### PR TITLE
Update StellarEventSource.swift

### DIFF
--- a/StellarKit/source/StellarEventSource.swift
+++ b/StellarKit/source/StellarEventSource.swift
@@ -232,7 +232,7 @@ public final class StellarEventSource: NSObject, URLSessionDataDelegate {
             }
         }
         else {
-            emitter.finish()
+            emitter?.finish()
         }
     }
 }


### PR DESCRIPTION
access emitter optionally - to prevent a crash.